### PR TITLE
[feature/config] Organize paths related to the dataset and set the default LLM model.

### DIFF
--- a/evaluators/base.py
+++ b/evaluators/base.py
@@ -1,0 +1,14 @@
+import torch
+from typing import List, Dict, Tuple
+from transformers import AutoTokenizer, AutoModelForCausalLM
+
+class LLMBasedEvaluator:
+    def __init__(self, model_name: str) -> None:
+        super().__init__()
+        self.model_name = model_name
+
+    def __call__(self, data: List[Dict[str, object]]) -> None:
+        return self.evaluate(data)
+
+    def evaluate(self, data: List[Dict[str, object]]) -> None:
+        raise NotImplementedError("Subclasses must implement this method.")

--- a/evaluators/base.py
+++ b/evaluators/base.py
@@ -6,6 +6,19 @@ class LLMBasedEvaluator:
     def __init__(self, model_name: str) -> None:
         super().__init__()
         self.model_name = model_name
+        self.tokenizer, self.model = self.load_model_and_tokenizer()
+
+    def load_model_and_tokenizer(self) -> Tuple[AutoTokenizer, AutoModelForCausalLM]:
+        try:
+            device = "cuda" if torch.cuda.is_available() else "cpu"
+            if device == "cuda" and not torch.cuda.is_available():
+                raise RuntimeError("CUDA is expected but not available on this machine.")
+            
+            tokenizer = AutoTokenizer.from_pretrained(self.model_name)
+            model = AutoModelForCausalLM.from_pretrained(self.model_name).to(device)
+            return tokenizer, model
+        except Exception as e:
+            raise Exception(f"Failed to load model or tokenizer for '{self.model_name}': {e}")
 
     def __call__(self, data: List[Dict[str, object]]) -> None:
         return self.evaluate(data)

--- a/settings/config.py
+++ b/settings/config.py
@@ -1,0 +1,21 @@
+# Paths to the JSON data files.
+DATA_PATHS = {
+    "review": "./data/review.json",
+    "translation": "./data/translation.json"
+}
+
+# Paths to the pre-defined system prompt files.
+PROMPT_PATHS = {
+    "review": "./data/system_prompts/review_prompt.txt",
+    "translation": "./data/system_prompts/translation_prompt.txt",
+    "translation_eval": "./data/system_prompts/translation_eval_prompt.txt"
+}
+
+# The number of required contents for each task.
+TASK_REQUIREMENTS = {
+  "review": 1,
+  "translation": 1,
+  "translation_eval": 2,
+}
+
+DEFAULT_MODEL_NAME = "meta-llama/Llama-3.2-3B-Instruct"


### PR DESCRIPTION
- Paths to the JSON data files
   - For maintenance, generate a dictionary to fetch paths
- Paths to the system prompt templates for each task
   - This is also organized as a dictionary type.
- Default model name

Adding more tasks in this project will be easier in this way.