### PR TITLE
[feature/translation_evaluator] Implementation of TranslationQualityEvaluator class

### DIFF
--- a/data/system_prompts/translation_eval_prompt.txt
+++ b/data/system_prompts/translation_eval_prompt.txt
@@ -1,0 +1,10 @@
+You will be provided with a Korean input text and its corresponding English translation.
+Your task is to evaluate the translation quality as low, medium, or high.
+Additionally, assign a confidence score as a float between 0 and 1, reflecting your certainty in the evaluation.
+
+Instructions:
+Provide your evaluation in the following format:
+Quality (low, medium, or high), Confidence (0.0 - 1.0)
+
+Ensure that you understand these instructions clearly.
+Your response should consist only of a single word (low, medium, or high) and a confidence score in float format.

--- a/data/system_prompts/translation_prompt.txt
+++ b/data/system_prompts/translation_prompt.txt
@@ -1,0 +1,4 @@
+You will be given an input_text written in Korean.
+Your task is to translate the text to English.
+Please ensure you comprehend these instructions fully.
+Your response should consist only a translated text written in English.

--- a/evaluators/translation.py
+++ b/evaluators/translation.py
@@ -37,6 +37,11 @@ class TranslationQualityEvaluator(LLMBasedEvaluator):
                 confidence_scores.append(confidence)
                 individual_results.append(ind_result)
 
+            # Compute core metrics
+            y_pred = data_df["quality"].values.tolist()
+            avg_confidence = calculate_avg(confidence_scores)
+            overall_results = self.metrics_manager.compute_core_metrics(y_true, y_pred, average="macro")
+            overall_results["avg_confidence"] = avg_confidence
                 
             # Compute additional metrics if required
             if self.metrics_manager.enable_bleu_rouge:

--- a/evaluators/translation.py
+++ b/evaluators/translation.py
@@ -45,7 +45,12 @@ class TranslationQualityEvaluator(LLMBasedEvaluator):
                 
             # Compute additional metrics if required
             if self.metrics_manager.enable_bleu_rouge:
-                pass
+                ind_extra_results, avg_extra_results = self.translate(data)
+                individual_results = [
+                    {**ind_res, "bleu": ind_bleu, "rouge_1": ind_rouge_1, "rouge_2": ind_rouge_2, "rouge_l": ind_rouge_l}
+                    for ind_res, ind_bleu, ind_rouge_1, ind_rouge_2, ind_rouge_l in zip(individual_results, ind_extra_results["bleu"], ind_extra_results["rouge_1"], ind_extra_results["rouge_2"], ind_extra_results["rouge_l"])
+                ]
+                overall_results.update(avg_extra_results)
 
             return {
                 "individual_results": individual_results,

--- a/evaluators/translation.py
+++ b/evaluators/translation.py
@@ -1,6 +1,7 @@
 import pandas as pd
 from typing import List, Dict
 
+from utils.helpers import find_pattern, calculate_avg
 from evaluators.base import LLMBasedEvaluator
 
 class TranslationQualityEvaluator(LLMBasedEvaluator):
@@ -9,11 +10,27 @@ class TranslationQualityEvaluator(LLMBasedEvaluator):
             raise ValueError("Input data for evaluation is empty.")
 
         try:
+            y_true, confidence_scores, individual_results, overall_results = [], [], [], []
             data_df = pd.DataFrame(data)
+            
+            if not {'input_text', 'translated_text', 'quality'}.issubset(data_df.columns):
+                raise ValueError("Input data must contain 'input_text', 'translated_text', and 'quality' fields.")
 
             for row in data_df.itertuples():
-                input_text = row.input_text
-                translated_text = row.translated_text
+                # Format the prompt for translation evaluation
+                prompt = self.prompt_manager.format_prompt('translation_eval', [row.input_text, row.translated_text])
+
+                # Perform inference
+                result = self.inference(prompt)
+                
+            # Compute additional metrics if required
+            if self.metrics_manager.enable_bleu_rouge:
+                pass
+
+            return {
+                "individual_results": individual_results,
+                "overall_results": overall_results
+            }
 
         except Exception as e:
             raise Exception(f"An error occurred during evaluation: {e}")

--- a/evaluators/translation.py
+++ b/evaluators/translation.py
@@ -66,12 +66,30 @@ class TranslationQualityEvaluator(LLMBasedEvaluator):
 
                 # Perform inference
                 result = self.inference(prompt)
+                                
+                # Extract the translated text
+                pattern = r'^[^\n]+(?=\n|$)'
+                translation = self.get_translated_text(pattern, result)
+                references.append(translation)
+                translated_texts.append(row.translated_text)
 
             ind_extra_results, avg_extra_results = self.metrics_manager.compute_extra_metrics(references, translated_texts)
             return ind_extra_results, avg_extra_results
 
         except Exception as e:
             raise Exception(f"An error occurred during translation or score computation: {e}")
+
+
+    def get_translated_text(self, pattern: str, source_text: str) -> str:
+        try:
+            match = find_pattern(pattern, source_text)
+            if match:
+                return match.group(0)
+            else:
+                print("No valid pattern found in the source text.")
+                return None
+        except Exception as e:
+            raise Exception(f"An error occurred while extracting translated text: {e}")
 
 
     def get_quality_confidence(self, pattern: str, source_text: str) -> (str, float):

--- a/evaluators/translation.py
+++ b/evaluators/translation.py
@@ -1,0 +1,19 @@
+import pandas as pd
+from typing import List, Dict
+
+from evaluators.base import LLMBasedEvaluator
+
+class TranslationQualityEvaluator(LLMBasedEvaluator):
+    def evaluate(self, data: List[Dict[str, str]]):
+        if not data:
+            raise ValueError("Input data for evaluation is empty.")
+
+        try:
+            data_df = pd.DataFrame(data)
+
+            for row in data_df.itertuples():
+                input_text = row.input_text
+                translated_text = row.translated_text
+
+        except Exception as e:
+            raise Exception(f"An error occurred during evaluation: {e}")

--- a/evaluators/translation.py
+++ b/evaluators/translation.py
@@ -56,6 +56,24 @@ class TranslationQualityEvaluator(LLMBasedEvaluator):
             raise Exception(f"An error occurred during evaluation: {e}")
 
 
+    def translate(self, data: List[Dict[str, str]]) -> (Dict[str, List[float]], Dict[str, float]):
+        try:
+            data_df = pd.DataFrame(data)
+            references, translated_texts = [], []
+            for row in data_df.itertuples():
+                # Format the prompt for translation
+                prompt = self.prompt_manager.format_prompt('translation', [row.input_text])
+
+                # Perform inference
+                result = self.inference(prompt)
+
+            ind_extra_results, avg_extra_results = self.metrics_manager.compute_extra_metrics(references, translated_texts)
+            return ind_extra_results, avg_extra_results
+
+        except Exception as e:
+            raise Exception(f"An error occurred during translation or score computation: {e}")
+
+
     def get_quality_confidence(self, pattern: str, source_text: str) -> (str, float):
         try:
             match = find_pattern(pattern, source_text)


### PR DESCRIPTION
- TranslationQualityEvaluator class consists of two tasks: translation evaluation, translation.
   - Translation evaluation task is to check whether the translated_text given as an input is compatible to the input_text.
      - This part calculates core metrics (accuracy, recall, precision, f1, confidence).
   - Translation task gets translation from the LLM and compare it with the translated_text, then compute BLEU and ROUGE scores as a metrics.
- By enabling --enable-bleu-rouge argument, you can get BLEU and ROUGE scores.